### PR TITLE
Update grunt-sass to version 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "grunt-contrib-connect": "^0.11.2",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-mocha-cli": "^2.0.0",
-    "grunt-sass": "^1.1.0-beta",
+    "grunt-sass": "^1.1.0",
     "grunt-sassdoc": "^2.0.1",
     "load-grunt-tasks": "^3.1.0",
     "sass-true": "^2.0.2"


### PR DESCRIPTION
Version grunt-sass 1.1.0-beta was failing to install on my computer. Updating to 1.1.0 works though.
